### PR TITLE
Update decky-frontend-lib to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "typescript": "^4.9.5"
   },
   "dependencies": {
-    "decky-frontend-lib": "^3.19.1",
+    "decky-frontend-lib": "^3.24.5",
     "lodash": "^4.17.21",
     "react-icons": "^4.8.0"
   },


### PR DESCRIPTION
As explained in https://github.com/SteamDeckHomebrew/decky-frontend-lib/issues/101, a more recent frontend lib version is required to fix the console log spamming.

Built and tested on LCD 3.5.17 & Decky 2.11.1. Still functions as expected.